### PR TITLE
PM-851 - added clientResponseUrl parameter to GET response

### DIFF
--- a/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
@@ -4,12 +4,12 @@ import it.pagopa.pm.gateway.dto.enums.OutcomeEnum;
 import lombok.*;
 
 @Data
-@AllArgsConstructor
 public class PostePayPollingResponse {
 
     String channel;
     String urlRedirect;
     OutcomeEnum authOutcome;
+    String clientResponseUrl;
     String error;
 
 }

--- a/src/test/java/it/pagopa/pm/gateway/beans/ValidBeans.java
+++ b/src/test/java/it/pagopa/pm/gateway/beans/ValidBeans.java
@@ -251,9 +251,14 @@ public class ValidBeans {
     }
 
     public static PostePayPollingResponse postePayPollingResponse() {
-        return new PostePayPollingResponse("APP", "www.userRedirectUrl.com", OutcomeEnum.OK, null);
+        PostePayPollingResponse postePayPollingResponse = new PostePayPollingResponse();
+        postePayPollingResponse.setChannel(PaymentChannel.APP.getValue());
+        postePayPollingResponse.setUrlRedirect("www.userRedirectUrl.com");
+        postePayPollingResponse.setAuthOutcome(OutcomeEnum.OK);
+        postePayPollingResponse.setClientResponseUrl("${postepay.pgs.response.clientResponseUrl}www.userRedirectUrl.com");
+        postePayPollingResponse.setError(StringUtils.EMPTY);
+        return postePayPollingResponse;
     }
-
 }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
A new parameter "clientResponseUrl" has been added to the GET response body in order to make the webview know where to redirect after the response from PUT request has been acquired.
This parameter is valued only when an affirmative authorization response (PUT request) from PostePay has been received, otherwise this field would be null, as well as "urlRedirect".
#### List of Changes

<!--- Describe your changes in detail -->
A new parameter "clientResponseUrl" has been added to the GET response body.
Tests also have been integrated accordingly.
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
JSON response when an OK authorization has been granted (via PUT request):
![image](https://user-images.githubusercontent.com/61983643/172201675-49bd2788-1480-4968-bf8a-8719727bc217.png)

JSON response when an authorization response has not been received yet:
![image](https://user-images.githubusercontent.com/61983643/172201032-8497e615-af3d-4135-8dca-0152f915819a.png)

JSON response when receiving an authorization KO (via PUT request):
![image](https://user-images.githubusercontent.com/61983643/172201504-02e6279a-bd0b-433b-b814-d414306445f4.png)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

### Link to story

<!-- Please insert link to the story relative to this task-->