### PR TITLE
PM-896 - Definition of DELETE API Inside the Swagger

### DIFF
--- a/api-specs/api_spec_PGS.yaml
+++ b/api-specs/api_spec_PGS.yaml
@@ -306,7 +306,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-
+    delete:
+      tags:
+        - payment-transactions-controller
+      summary: refund PostePay requests
+      operationId: refund-request
+      parameters:
+        - in: path
+          name: requestId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: PGS-generated GUID of the request to retrieve
+          example: 77e1c83b-7bb0-437b-bc50-a7a58e5660ac
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+        "404":
+          description: Request doesn't exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+        "500":
+          description: Generic Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+      "502":
+        description: Gateway Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+      "504":
+        description: Request timeout
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
 components:
   schemas:
     AuthMessage:
@@ -485,3 +529,20 @@ components:
       required:
         - code
         - message
+    PostePayRefundResponse:
+      type: object
+      properties:
+        transactionId:
+          type: integer
+          format: int64
+        paymentId:
+          type: string
+        refundOutcome:
+          type: string
+        error:
+          type: string
+      required:
+        - transactionId
+        - paymentId
+        - refundOutcome
+        - error


### PR DESCRIPTION
Added DELETE API to the Swagger for the definition of refund method for PostePay methods

#### List of Changes

Added method definition, added object response definition (PostePayRefundResponse)

#### Motivation and Context

It's necessary to introduce a new method that allows users to refund PostePay transactions

#### How Has This Been Tested?

By building correctly the application, without compilation or other type of errors.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

### Link to story

https://pagopa.atlassian.net/browse/PM-896