### PR TITLE
PM-896 - Fixed Return Object into Swagger

### DIFF
--- a/api-specs/api_spec_PGS.yaml
+++ b/api-specs/api_spec_PGS.yaml
@@ -532,9 +532,8 @@ components:
     PostePayRefundResponse:
       type: object
       properties:
-        transactionId:
-          type: integer
-          format: int64
+        requestId:
+          type: string
         paymentId:
           type: string
         refundOutcome:


### PR DESCRIPTION
Changed Return Object Parameter (from transactionId to requestId)

#### List of Changes

Fixed the swagger file within the definition of the object returned by DELETE API

#### Motivation and Context

Initially PM passed the transactionId to PGS, but the method definition said that the requestId must be read by PGS, so the path parameter was changed

#### How Has This Been Tested?

By building the application and seeing no compilation errors

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

### Link to story

https://pagopa.atlassian.net/browse/PM-896