### PR TITLE
PM-903 - Added Annotation to Remove Null Fields on Responses

### DIFF
--- a/src/main/java/it/pagopa/pm/gateway/dto/PostePayAuthResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/PostePayAuthResponse.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 @Data
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostePayAuthResponse {
 
    String channel;

--- a/src/main/java/it/pagopa/pm/gateway/dto/PostePayAuthResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/PostePayAuthResponse.java
@@ -1,9 +1,11 @@
 package it.pagopa.pm.gateway.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostePayAuthResponse {
 
    String channel;

--- a/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
@@ -1,9 +1,11 @@
 package it.pagopa.pm.gateway.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import it.pagopa.pm.gateway.dto.enums.OutcomeEnum;
 import lombok.*;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PostePayPollingResponse {
 
     String channel;


### PR DESCRIPTION
API responses now show only setted fields

#### List of Changes

Added NON_NULL JSON annotation into the response's classes

#### Motivation and Context

For removing decoding of the responses' read, fields setted with "null" value mustn't be showed on the JSON response

#### How Has This Been Tested?

By building and run the application

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

### Link to story

https://pagopa.atlassian.net/browse/PM-903