### PR TITLE
Pm 908 fix closepayment api declaration

### DIFF
--- a/api-specs/api_spec_PGS.yaml
+++ b/api-specs/api_spec_PGS.yaml
@@ -192,6 +192,51 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PollingResponseEntity'
+    delete:
+      tags:
+        - payment-transactions-controller
+      summary: refund PostePay requests
+      operationId: refund-request
+      parameters:
+        - in: path
+          name: requestId
+          schema:
+            type: string
+            format: uuid
+          required: true
+          description: PGS-generated GUID of the request to retrieve
+          example: 77e1c83b-7bb0-437b-bc50-a7a58e5660ac
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+        "404":
+          description: Request doesn't exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+        "500":
+          description: Generic Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+        "502":
+          description: Gateway Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
+        "504":
+          description: Request timeout
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PostePayRefundResponse'
   /request-payments/postepay:
     post:
       summary: payment authorization request to PostePay
@@ -306,51 +351,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-    delete:
-      tags:
-        - payment-transactions-controller
-      summary: refund PostePay requests
-      operationId: refund-request
-      parameters:
-        - in: path
-          name: requestId
-          schema:
-            type: string
-            format: uuid
-          required: true
-          description: PGS-generated GUID of the request to retrieve
-          example: 77e1c83b-7bb0-437b-bc50-a7a58e5660ac
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostePayRefundResponse'
-        "404":
-          description: Request doesn't exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostePayRefundResponse'
-        "500":
-          description: Generic Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostePayRefundResponse'
-      "502":
-        description: Gateway Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostePayRefundResponse'
-      "504":
-        description: Request timeout
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PostePayRefundResponse'
 components:
   schemas:
     AuthMessage:

--- a/src/main/java/it/pagopa/pm/gateway/client/restapicd/RestapiCdClient.java
+++ b/src/main/java/it/pagopa/pm/gateway/client/restapicd/RestapiCdClient.java
@@ -11,7 +11,7 @@ public interface RestapiCdClient {
     @RequestLine("PATCH /pp-restapi-CD/v1/transactions/update-status/{id}")
     void updateTransaction(@Param Long id, @HeaderMap Map<String, Object> headerMap, TransactionUpdateRequestData transactionUpdateRequest);
 
-    @RequestLine("POST /pp-restapi-CD/v1/payments/close-payment/{idTransaction}?{parameters}")
-    String closePayment(@Param Long idTransaction, @QueryMap Map<String, Object> parameters,
+    @RequestLine("PATCH /pp-restapi-CD/v2/transactions/{id}?{parameters}")
+    String closePayment(@Param Long id, @QueryMap Map<String, Object> parameters,
                         @HeaderMap Map<String, Object> headerMap);
 }

--- a/src/main/java/it/pagopa/pm/gateway/client/restapicd/RestapiCdClientImpl.java
+++ b/src/main/java/it/pagopa/pm/gateway/client/restapicd/RestapiCdClientImpl.java
@@ -20,8 +20,8 @@ import static it.pagopa.pm.gateway.utils.MdcUtils.buildMdcHeader;
 @Component
 public class RestapiCdClientImpl {
 
-    private static final String OUTCOME_PARAM = "outcome";
     private static final String AUTH_CODE_PARAM = "authCode";
+    private static final String RRN_PARAM = "rrn";
     @Value("${HOSTNAME_PM}")
     public String hostnamePm;
 
@@ -38,17 +38,17 @@ public class RestapiCdClientImpl {
         restapiCdClient.updateTransaction(id, headerMap, new TransactionUpdateRequestData(request));
     }
 
-    public String callClosePayment(Long idTransaction, boolean outcome, String authCode) {
-        log.info("Calling Payment Manager's closePayment for transaction " + idTransaction);
+    public String callClosePayment(Long id, String authCode, String rrn) {
+        log.info("Calling Payment Manager's closePayment for transaction " + id);
         Map<String, Object> headerMap = buildMdcHeader();
-        Map<String, Object> parameters = buildQueryParameters(outcome, authCode);
-        return restapiCdClient.closePayment(idTransaction, parameters, headerMap);
+        Map<String, Object> parameters = buildQueryParameters(authCode, rrn);
+        return restapiCdClient.closePayment(id, parameters, headerMap);
     }
 
-    private Map<String, Object> buildQueryParameters(boolean outcome, String authCode) {
+    private Map<String, Object> buildQueryParameters(String authCode, String rrn) {
         Map<String, Object> parameters = new LinkedHashMap<>();
-        parameters.put(OUTCOME_PARAM, outcome);
         parameters.put(AUTH_CODE_PARAM, authCode);
+        parameters.put(RRN_PARAM, rrn);
         return parameters;
     }
 

--- a/src/main/java/it/pagopa/pm/gateway/controller/PostePayPaymentTransactionsController.java
+++ b/src/main/java/it/pagopa/pm/gateway/controller/PostePayPaymentTransactionsController.java
@@ -93,7 +93,7 @@ public class PostePayPaymentTransactionsController {
 
         try {
             boolean isAuthOutcomeOk = authMessage.getAuthOutcome() == OK;
-            String closePaymentResult = restapiCdClient.callClosePayment(requestEntity.getIdTransaction(), isAuthOutcomeOk, authMessage.getAuthCode());
+            String closePaymentResult = restapiCdClient.callClosePayment(requestEntity.getIdTransaction(), authMessage.getAuthCode(), correlationId);
             log.info("Response from closePayment for correlation-id: " + correlationId + " " + closePaymentResult);
             requestEntity.setIsProcessed(true);
             requestEntity.setAuthorizationOutcome(isAuthOutcomeOk);

--- a/src/test/java/it/pagopa/pm/gateway/controller/PostePayPaymentControllerTest.java
+++ b/src/test/java/it/pagopa/pm/gateway/controller/PostePayPaymentControllerTest.java
@@ -313,7 +313,7 @@ public class PostePayPaymentControllerTest {
         PaymentRequestEntity paymentRequestEntity = ValidBeans.paymentRequestEntity(null, true, "APP");
 
         given( paymentRequestRepository.findByCorrelationIdAndRequestEndpoint(correlationID, EndpointEnum.POSTEPAY.getValue())).willReturn(paymentRequestEntity);
-        given(restapiCdClient.callClosePayment(paymentRequestEntity.getIdTransaction(), true, authMessage.getAuthCode()))
+        given(restapiCdClient.callClosePayment(paymentRequestEntity.getIdTransaction(), authMessage.getAuthCode(), correlationID))
                 .willReturn(OutcomeEnum.OK.toString());
 
         mvc.perform(put(ApiPaths.REQUEST_PAYMENTS_POSTEPAY)
@@ -387,7 +387,7 @@ public class PostePayPaymentControllerTest {
 
         doThrow(FeignException.class)
                 .when(restapiCdClient)
-                .callClosePayment(paymentRequestEntity.getIdTransaction(), true, authMessage.getAuthCode());
+                .callClosePayment(paymentRequestEntity.getIdTransaction(), authMessage.getAuthCode(), correlationID);
 
         given(paymentRequestRepository.findByCorrelationIdAndRequestEndpoint(correlationID, EndpointEnum.POSTEPAY.getValue())).willReturn(paymentRequestEntity);
 
@@ -416,7 +416,7 @@ public class PostePayPaymentControllerTest {
 
         doThrow(RuntimeException.class)
                 .when(restapiCdClient)
-                .callClosePayment(paymentRequestEntity.getIdTransaction(), true, authMessage.getAuthCode());
+                .callClosePayment(paymentRequestEntity.getIdTransaction(), authMessage.getAuthCode(), correlationID);
 
         given(paymentRequestRepository.findByCorrelationIdAndRequestEndpoint(correlationID, EndpointEnum.POSTEPAY.getValue())).willReturn(paymentRequestEntity);
 


### PR DESCRIPTION
Changed call for the client after the PUT API

#### List of Changes

After the PUT call, we call the PATCH API (instead the initial POST) passing the authorization code and the RRN/correlation ID (instead a boolean that indicate the outcome of the payment request)

#### Motivation and Context

Initially there wasn't a clear documentation relative to this call, so we defined a method logically. Once the documentation was updated, the new type of implementation was requested.

#### How Has This Been Tested?

By running and debugging the application.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

### Link to story

https://pagopa.atlassian.net/browse/PM-908