### PR TITLE
PM-923 - Added ID and Correlation ID from Postepay Request to GET API

### DIFF
--- a/src/main/java/it/pagopa/pm/gateway/controller/PostePayPaymentTransactionsController.java
+++ b/src/main/java/it/pagopa/pm/gateway/controller/PostePayPaymentTransactionsController.java
@@ -336,6 +336,8 @@ public class PostePayPaymentTransactionsController {
         response.setUrlRedirect(urlRedirect);
         response.setAuthOutcome(authorizationOutcome);
         response.setChannel(entity.getClientId());
+        response.setRequestId(entity.getId());
+        response.setCorrelationId(entity.getCorrelationId());
         if (Objects.isNull(authorizationOutcome)) {
             log.warn("No authorization outcome has been received yet for requestId " + requestId);
             response.setError("No authorization outcome has been received yet");

--- a/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
@@ -16,5 +16,7 @@ public class PostePayPollingResponse {
     OutcomeEnum authOutcome;
     String error;
     StatusErrorCodeOutcomeEnum statusErrorCodeOutcome;
+    Long requestId;
+    String correlationId;
 
 }


### PR DESCRIPTION
Response from GET API now return correlation and request IDs.

#### List of Changes

Added two properties, requestId and correlationId, to the object PostePayPollingResponse.

#### Motivation and Context

To simplify the tests with the passing of parameters, the GET method response must be the new properties inside.

#### How Has This Been Tested?

By running and debugging the application.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

### Link to story

https://pagopa.atlassian.net/browse/PM-923