### PR TITLE
PM-923 - Replaced request ID with its GUID into the GET Response

### DIFF
--- a/src/main/java/it/pagopa/pm/gateway/controller/PostePayPaymentTransactionsController.java
+++ b/src/main/java/it/pagopa/pm/gateway/controller/PostePayPaymentTransactionsController.java
@@ -340,7 +340,7 @@ public class PostePayPaymentTransactionsController {
         response.setUrlRedirect(urlRedirect);
         response.setAuthOutcome(authorizationOutcome);
         response.setChannel(entity.getClientId());
-        response.setRequestId(entity.getId());
+        response.setGuid(entity.getGuid());
         response.setCorrelationId(entity.getCorrelationId());
         if (Objects.isNull(authorizationOutcome)) {
             log.warn("No authorization outcome has been received yet for requestId " + requestId);

--- a/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/PostePayPollingResponse.java
@@ -16,7 +16,7 @@ public class PostePayPollingResponse {
     OutcomeEnum authOutcome;
     String error;
     StatusErrorCodeOutcomeEnum statusErrorCodeOutcome;
-    Long requestId;
+    String guid;
     String correlationId;
 
 }


### PR DESCRIPTION
The GET API response ha now the GUID instead the ID of the payment request.

#### List of Changes

Inside the class PostePayPollingResponse, was replaced the requestId field (mapping the ID field of the table PP_PGS_REQUEST_INFO) with the guid field (mapping the GUID of the same table).

#### Motivation and Context

The ID field isn't necessary for the payment flow. It was replaced by GUID field, more important for the tests.

#### How Has This Been Tested?

By running and debugging the application.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

### Link to story

https://pagopa.atlassian.net/browse/PM-923