### PR TITLE
PM-1203 - reversal as fallback when PATCH calls fail

### DIFF
--- a/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
+++ b/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
@@ -184,12 +184,12 @@ public class XPayPaymentController {
 
         if (Objects.isNull(entity)) {
             log.error(REQUEST_ID_NOT_FOUND_MSG);
-            return createXPayRefundRespone(requestId, HttpStatus.NOT_FOUND, null);
+            return createXPayRefundResponse(requestId, HttpStatus.NOT_FOUND, null);
         }
 
         if (BooleanUtils.isTrue(entity.getIsRefunded())) {
             log.info("RequestId " + requestId + " has been refunded already. Skipping refund");
-            return createXPayRefundRespone(requestId, HttpStatus.OK, null);
+            return createXPayRefundResponse(requestId, HttpStatus.OK, null);
         }
 
         EsitoXpay refundOutcome = null;
@@ -198,9 +198,9 @@ public class XPayPaymentController {
             if (outcomeOrderStatus.equals(OK)) {
                 refundOutcome = executeXPayRevert(entity);
             }
-            return createXPayRefundRespone(requestId, HttpStatus.OK, refundOutcome);
+            return createXPayRefundResponse(requestId, HttpStatus.OK, refundOutcome);
         } catch (Exception e) {
-            return createXPayRefundRespone(requestId, HttpStatus.INTERNAL_SERVER_ERROR, null);
+            return createXPayRefundResponse(requestId, HttpStatus.INTERNAL_SERVER_ERROR, null);
         }
     }
 
@@ -436,7 +436,7 @@ public class XPayPaymentController {
         }
     }
 
-    private ResponseEntity<XPayRefundResponse> createXPayRefundRespone(String requestId, HttpStatus httpStatus, EsitoXpay refundOutcome) {
+    private ResponseEntity<XPayRefundResponse> createXPayRefundResponse(String requestId, HttpStatus httpStatus, EsitoXpay refundOutcome) {
         XPayRefundResponse response = new XPayRefundResponse();
         response.setRequestId(requestId);
 

--- a/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
+++ b/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
@@ -178,10 +178,8 @@ public class XPayPaymentController {
     }
 
     @DeleteMapping(REQUEST_ID)
-    public ResponseEntity<XPayRefundResponse> xPayRefund(@PathVariable String requestId) {
-
+    public ResponseEntity<XPayRefundResponse> refundXpayPayment(@PathVariable String requestId) {
         log.info("START - requesting XPay refund for requestId: " + requestId);
-
         PaymentRequestEntity entity = paymentRequestRepository.findByGuid(requestId);
 
         if (Objects.isNull(entity)) {
@@ -200,10 +198,10 @@ public class XPayPaymentController {
             if (outcomeOrderStatus.equals(OK)) {
                 refundOutcome = executeXPayRevert(entity);
             }
+            return createXPayRefundRespone(requestId, HttpStatus.OK, refundOutcome);
         } catch (Exception e) {
             return createXPayRefundRespone(requestId, HttpStatus.INTERNAL_SERVER_ERROR, null);
         }
-        return createXPayRefundRespone(requestId, HttpStatus.OK, refundOutcome);
     }
 
     private ResponseEntity<XPayAuthResponse> createAuthPaymentXpay(XPayAuthRequest pgsRequest, String clientId, String mdcFields) {
@@ -364,9 +362,9 @@ public class XPayPaymentController {
             log.info(String.format("Response from PATCH updateTransaction for requestId %s is %s", requestId, result));
         } catch (Exception e) {
             log.error(PATCH_CLOSE_PAYMENT_ERROR + requestId, e);
-            entity.setStatus(CANCELLED.name());
+            log.info("Refunding payment with requestId: " + requestId);
+            refundXpayPayment(requestId);
         }
-        paymentRequestRepository.save(entity);
     }
 
     private XPay3DSResponse buildXPay3DSResponse(Map<String, String> params) {
@@ -408,33 +406,34 @@ public class XPayPaymentController {
         String requestId = entity.getGuid();
         XPayOrderStatusResponse response;
         try {
-            log.info("START executeXPayOrderStatus for requestId " + requestId);
+            log.info("Calling situazioneOrdine for requestId " + requestId);
             XPayOrderStatusRequest request = createXPayOrderStatusRequest(entity);
             response = xpayService.callSituazioneOrdine(request);
+            return response.getEsito();
         } catch (Exception e) {
-            log.error(GENERIC_REFUND_ERROR_MSG + requestId, e);
+            log.error("Error while calling XPay's situazioneOrdine API for requestId " + requestId, e);
             throw e;
         }
-        return response.getEsito();
     }
 
     private EsitoXpay executeXPayRevert(PaymentRequestEntity entity) throws Exception {
         String requestId = entity.getGuid();
-        XPayRevertResponse response;
         try {
-            log.info("START executeXPayOrderStatus for requestId " + requestId);
+            log.info("Calling revert API for requestId " + requestId);
             XPayRevertRequest request = createXPayRevertRequest(entity);
-            response = xpayService.callStorna(request);
+            XPayRevertResponse response = xpayService.callStorna(request);
+            EsitoXpay outcome = response.getEsito();
+            log.info(String.format("XPay response to revert API is %s for requestId %s", outcome, requestId));
+            if (outcome.equals(OK)) {
+                entity.setStatus(CANCELLED.name());
+                entity.setIsRefunded(true);
+                paymentRequestRepository.save(entity);
+            }
+            return outcome;
         } catch (Exception e) {
             log.error(GENERIC_REFUND_ERROR_MSG + requestId, e);
             throw e;
         }
-        if (response.getEsito().equals(OK)) {
-            entity.setStatus(CANCELLED.name());
-            entity.setIsRefunded(Boolean.TRUE);
-            paymentRequestRepository.save(entity);
-        }
-        return response.getEsito();
     }
 
     private ResponseEntity<XPayRefundResponse> createXPayRefundRespone(String requestId, HttpStatus httpStatus, EsitoXpay refundOutcome) {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR contains improvements within the resume flow for an XPay payment.
In detail, when the call to PATCH API fails, the DELETE API's logic flow is called to cancel the payment on XPay side.
As a consequence, both status and isRefunded columns on PGS's DB are changed accordingly.
#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

### Link to story

<!-- Please insert link to the story relative to this task-->
https://pagopa.atlassian.net/browse/PM-1201
https://pagopa.atlassian.net/browse/PM-1203