### PR TITLE
PM-1404 XPAY and VPOS responses standardization

### DIFF
--- a/api-specs/api_spec_PGS.yaml
+++ b/api-specs/api_spec_PGS.yaml
@@ -942,15 +942,11 @@ components:
           type: string
         paymentId:
           type: string
-        refundOutcome:
-          type: string
-          enum: [OK, KO]
         error:
           type: string
       required:
         - transactionId
         - paymentId
-        - refundOutcome
         - error
     XPayAuthRequest:
       required:
@@ -1062,6 +1058,7 @@ components:
       required:
         - status
         - requestId
+        - redirectUrl
       properties:
         html:
           type: string
@@ -1076,10 +1073,6 @@ components:
           enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]
           description: status
           example: CREATED
-        authOutcome:
-          type: string
-          description: authorization outcome received from XPay
-          example: OK
         authCode:
           type: string
           description: authorization code received from XPay
@@ -1114,15 +1107,14 @@ components:
         requestId:
           type: string
           example: "77e1c83b-7bb0-437b-bc50-a7a58e5660ac"
-        refundOutcome:
-          type: string
-          enum: [OK, KO]
-          example: "OK"
         error:
           type: string
+        status:
+          type: string
+          enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]
       required:
         - transactionId
-        - refundOutcome
+        - status
     XPayRefundResponse404:
       type: object
       properties:
@@ -1144,9 +1136,13 @@ components:
         error:
           type: string
           example: "Error while requesting refund for requestId: xxx"
+        status:
+          type: string
+          enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]
       required:
         - transactionId
         - error
+        - status
     BPayInfoResponse:
       type: object
       properties:
@@ -1267,14 +1263,11 @@ components:
         status:
           type: string
           enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]
-        responseType:
-          type: string
-          enum: [METHOD, CHALLENGE, AUTHORIZATION, ERROR]
         requestId:
           type: string
         vposUrl:
           type: string
-        clientReturnUrl:
+        redirectUrl:
           type: string
         threeDsMethodData:
           type: string
@@ -1314,21 +1307,34 @@ components:
           enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]
         requestId:
           type: string
-        clientReturnUrl:
+        redirectUrl:
           type: string
         creq:
           type: string
           format: base64
+        authCode:
+          type: string
+          description: authorization code received from XPay
+          example: 123
       required:
         - status
         - requestId
-        - clientReturnUrl
+        - redirectUrl
+        - authCode
     CcPaymentInfoError:
       type: object
       properties:
-        reason:
+        redirectUrl:
           type: string
-          example: "RequestId non trovato"
+        status:
+          type: string
+          enum: [DENIED, CANCELLED]
+        requestId:
+          type: string
+      required:
+        - status
+        - requestId
+        - redirectUrl
     CreditCardResumeRequest:
       type: object
       required:
@@ -1350,15 +1356,10 @@ components:
       type: object
       required:
         - requestId
-        - refundOutcome
         - status
       properties:
         requestId:
           type: string
-        refundOutcome:
-          type: string
-          enum:
-            [OK, KO]
         status:
           type: string
           enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]
@@ -1369,15 +1370,10 @@ components:
       type: object
       required:
         - requestId
-        - refundOutcome
         - error
       properties:
         requestId:
           type: string
-        refundOutcome:
-          type: string
-          enum:
-            [OK, KO]
         status:
           type: string
           enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]
@@ -1387,16 +1383,11 @@ components:
       type: object
       required:
         - requestId
-        - refundOutcome
         - status
         - error
       properties:
         requestId:
           type: string
-        refundOutcome:
-          type: string
-          enum:
-            [OK, KO]
         status:
           type: string
           enum: [CREATED, AUTHORIZED, DENIED, CANCELLED]

--- a/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
+++ b/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
@@ -500,7 +500,7 @@ public class XPayPaymentController {
             response.setError(REQUEST_ID_NOT_FOUND_MSG);
         } else if (httpStatus.is2xxSuccessful() && Objects.isNull(refundOutcome)) {
             response.setError("RequestId " + requestId + " has been refunded already. Skipping refund");
-        } else {
+        } else if(!httpStatus.is2xxSuccessful()) {
             response.setError(GENERIC_REFUND_ERROR_MSG + requestId);
         }
 

--- a/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
+++ b/src/main/java/it/pagopa/pm/gateway/controller/XPayPaymentController.java
@@ -140,7 +140,9 @@ public class XPayPaymentController {
             return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(pollingUrlRedirect)).build();
         }
 
-        if (outcome.equals(OK) && checkResumeRequest(entity, requestId, xPay3DSResponse)) {
+        if (outcome.equals(OK) && checkResumeRequest(entity, requestId, xPay3DSResponse)
+                && "CREATED".equals(entity.getStatus())) {
+
             executeXPayPaymentCall(requestId, xPay3DSResponse, entity);
         } else {
             log.info(String.format("Outcome is %s: setting status as DENIED for requestId %s", outcome, requestId));
@@ -180,12 +182,12 @@ public class XPayPaymentController {
 
         if (Objects.isNull(entity)) {
             log.error(REQUEST_ID_NOT_FOUND_MSG);
-            return createXPayRefundResponse(requestId, HttpStatus.NOT_FOUND, null);
+            return createXPayRefundResponse(requestId, HttpStatus.NOT_FOUND, null, null);
         }
 
         if (BooleanUtils.isTrue(entity.getIsRefunded())) {
             log.info("RequestId " + requestId + " has been refunded already. Skipping refund");
-            return createXPayRefundResponse(requestId, HttpStatus.OK, null);
+            return createXPayRefundResponse(requestId, HttpStatus.OK, null, entity);
         }
 
         EsitoXpay refundOutcome = null;
@@ -194,9 +196,9 @@ public class XPayPaymentController {
             if (outcomeOrderStatus.equals(OK)) {
                 refundOutcome = executeXPayRevert(entity);
             }
-            return createXPayRefundResponse(requestId, HttpStatus.OK, refundOutcome);
+            return createXPayRefundResponse(requestId, HttpStatus.OK, refundOutcome, entity);
         } catch (Exception e) {
-            return createXPayRefundResponse(requestId, HttpStatus.INTERNAL_SERVER_ERROR, null);
+            return createXPayRefundResponse(requestId, HttpStatus.INTERNAL_SERVER_ERROR, null, entity);
         }
     }
 
@@ -262,6 +264,8 @@ public class XPayPaymentController {
         String status = entity.getStatus();
         log.info(String.format("Request status for requestId %s is %s", requestId, status));
 
+        String clientReturnUrl = clientsConfig.getByKey(entity.getClientId()).getXpay().getClientReturnUrl();
+
         response.setStatus(status);
         PaymentRequestStatusEnum statusEnum = getEnumValueFromString(status);
         switch (statusEnum) {
@@ -277,16 +281,16 @@ public class XPayPaymentController {
             case DENIED:
                 String authOutcome = BooleanUtils.toBoolean(entity.getAuthorizationOutcome()) ? OK.name() : KO.name();
                 log.info(String.format("Authorization outcome for requestId %s is %s", requestId, authOutcome));
-                response.setAuthOutcome(authOutcome);
                 response.setAuthCode(entity.getAuthorizationCode());
 
-                String clientReturnUrl = clientsConfig.getByKey(entity.getClientId()).getXpay().getClientReturnUrl();
                 response.setRedirectUrl(StringUtils.join(clientReturnUrl, entity.getIdTransaction()));
                 break;
             default:
                 log.info(BooleanUtils.toBoolean(entity.getIsRefunded()) ?
                         String.format("XPay request with requestId %s has been refunded", requestId) :
                         String.format("XPay request with requestId %s has not been refunded yet", requestId));
+
+                response.setRedirectUrl(StringUtils.join(clientReturnUrl, entity.getIdTransaction()));
                 break;
         }
 
@@ -484,18 +488,18 @@ public class XPayPaymentController {
         }
     }
 
-    private ResponseEntity<XPayRefundResponse> createXPayRefundResponse(String requestId, HttpStatus httpStatus, EsitoXpay refundOutcome) {
+    private ResponseEntity<XPayRefundResponse> createXPayRefundResponse(String requestId, HttpStatus httpStatus,
+                                                                        EsitoXpay refundOutcome, PaymentRequestEntity entity) {
         XPayRefundResponse response = new XPayRefundResponse();
         response.setRequestId(requestId);
 
+        if(entity != null)
+            response.setStatus(entity.getStatus());
+
         if (httpStatus.is4xxClientError()) {
             response.setError(REQUEST_ID_NOT_FOUND_MSG);
-        } else if (httpStatus.is2xxSuccessful()) {
-            if (Objects.isNull(refundOutcome)) {
-                response.setError("RequestId " + requestId + " has been refunded already. Skipping refund");
-            } else {
-                response.setRefundOutcome(String.valueOf(refundOutcome));
-            }
+        } else if (httpStatus.is2xxSuccessful() && Objects.isNull(refundOutcome)) {
+            response.setError("RequestId " + requestId + " has been refunded already. Skipping refund");
         } else {
             response.setError(GENERIC_REFUND_ERROR_MSG + requestId);
         }

--- a/src/main/java/it/pagopa/pm/gateway/dto/creditcard/StepZeroResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/creditcard/StepZeroResponse.java
@@ -14,4 +14,5 @@ public class StepZeroResponse {
     private String error;
     private String requestId;
     private String status;
+    private String timeStamp;
 }

--- a/src/main/java/it/pagopa/pm/gateway/dto/vpos/CcPaymentInfoResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/vpos/CcPaymentInfoResponse.java
@@ -10,7 +10,8 @@ public class CcPaymentInfoResponse {
     private String responseType;
     private String requestId;
     private String vposUrl;
-    private String clientReturnUrl;
+    private String redirectUrl;
     private String threeDsMethodData;
     private String creq;
+    private String authCode;
 }

--- a/src/main/java/it/pagopa/pm/gateway/dto/vpos/VposDeleteResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/vpos/VposDeleteResponse.java
@@ -1,5 +1,6 @@
 package it.pagopa.pm.gateway.dto.vpos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,10 +8,9 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class VposDeleteResponse {
-
     private String requestId;
-    private String refundOutcome;
     private String status;
     private String error;
 }

--- a/src/main/java/it/pagopa/pm/gateway/dto/xpay/XPayAuthResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/xpay/XPayAuthResponse.java
@@ -10,11 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class XPayAuthResponse {
-
     private String urlRedirect;
     private String error;
     private String requestId;
     private String status;
     private String timeStamp;
-
 }

--- a/src/main/java/it/pagopa/pm/gateway/dto/xpay/XPayPollingResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/xpay/XPayPollingResponse.java
@@ -14,7 +14,6 @@ public class XPayPollingResponse {
     private String status;
     private XPayPollingResponseError error;
     private String html;
-    private String authOutcome;
     private String authCode;
     private String redirectUrl;
     private String requestId;

--- a/src/main/java/it/pagopa/pm/gateway/dto/xpay/XPayRefundResponse.java
+++ b/src/main/java/it/pagopa/pm/gateway/dto/xpay/XPayRefundResponse.java
@@ -1,5 +1,6 @@
 package it.pagopa.pm.gateway.dto.xpay;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,10 +8,9 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class XPayRefundResponse {
-
     String requestId;
-    String refundOutcome;
+    String status;
     String error;
-
 }

--- a/src/main/java/it/pagopa/pm/gateway/service/CcPaymentInfoService.java
+++ b/src/main/java/it/pagopa/pm/gateway/service/CcPaymentInfoService.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Base64Utils;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static it.pagopa.pm.gateway.constant.ApiPaths.REQUEST_PAYMENTS_VPOS;
@@ -32,6 +34,7 @@ public class CcPaymentInfoService {
     private static final String CHALLENGE = "CHALLENGE";
     private static final String CANCELLED = "CANCELLED";
     private static final String CREATED = "CREATED";
+    private static final List<String> UNFINISHED_STATES = Arrays.asList(CREATED, METHOD, CHALLENGE);
     private String methodNotifyUrl;
     private PaymentRequestRepository paymentRequestRepository;
     private ClientsConfig clientsConfig;
@@ -76,7 +79,7 @@ public class CcPaymentInfoService {
             response.setVposUrl(paymentInfo.getAuthorizationUrl());
         }
 
-        if(!CREATED.equals(paymentInfo.getStatus())) {
+        if(!UNFINISHED_STATES.contains(paymentInfo.getStatus())) {
             ClientConfig clientConfig = clientsConfig.getByKey(paymentInfo.getClientId());
             String clientReturnUrl = clientConfig.getXpay().getClientReturnUrl();
             response.setRedirectUrl(StringUtils.join(clientReturnUrl, idTransaction));

--- a/src/main/java/it/pagopa/pm/gateway/service/VposDeleteService.java
+++ b/src/main/java/it/pagopa/pm/gateway/service/VposDeleteService.java
@@ -62,12 +62,12 @@ public class VposDeleteService {
 
         if (Objects.isNull(entity)) {
             log.error(REQUEST_ID_NOT_FOUND_MSG);
-            return createDeleteResponse(requestId, REQUEST_ID_NOT_FOUND_MSG, KO, null);
+            return createDeleteResponse(requestId, REQUEST_ID_NOT_FOUND_MSG, null);
         }
 
         if (BooleanUtils.isTrue(entity.getIsRefunded())) {
             log.info("RequestId " + requestId + " has been refunded already. Skipping refund");
-            return createDeleteResponse(requestId, String.format(TRANSACTION_ALREADY_REFUND, entity.getIdTransaction()), KO, entity);
+            return createDeleteResponse(requestId, String.format(TRANSACTION_ALREADY_REFUND, entity.getIdTransaction()), entity);
         }
 
         RefundOutcome refundOutcome;
@@ -77,16 +77,16 @@ public class VposDeleteService {
             if (refundOutcome.equals(OK)) {
                 refundOutcome = executeRevert(entity, stepZeroRequest);
                 if (!refundOutcome.equals(OK)) {
-                    return createDeleteResponse(requestId, entity.getErrorMessage(), refundOutcome, entity);
+                    return createDeleteResponse(requestId, entity.getErrorMessage(), entity);
                 } else {
-                    return createDeleteResponse(requestId, null, refundOutcome, entity);
+                    return createDeleteResponse(requestId, null, entity);
                 }
             } else {
-                return createDeleteResponse(requestId, entity.getErrorMessage(), refundOutcome, entity);
+                return createDeleteResponse(requestId, entity.getErrorMessage(), entity);
             }
         } catch (Exception e) {
             log.error(GENERIC_ERROR_MSG + entity.getIdTransaction() + e);
-            return createDeleteResponse(requestId, GENERIC_REFUND_ERROR_MSG + requestId, KO, entity);
+            return createDeleteResponse(requestId, GENERIC_REFUND_ERROR_MSG + requestId, entity);
         }
     }
 
@@ -112,11 +112,10 @@ public class VposDeleteService {
         return saveRevertResultCode(response, entity);
     }
 
-    private VposDeleteResponse createDeleteResponse(String requestId, String errorMessage, RefundOutcome refundOutcome, PaymentRequestEntity entity) {
+    private VposDeleteResponse createDeleteResponse(String requestId, String errorMessage, PaymentRequestEntity entity) {
         VposDeleteResponse response = new VposDeleteResponse();
         response.setRequestId(requestId);
         response.setError(errorMessage);
-        response.setRefundOutcome(refundOutcome.name());
         if (Objects.nonNull(entity)) {
             response.setStatus(entity.getStatus());
         }

--- a/src/main/java/it/pagopa/pm/gateway/service/VposService.java
+++ b/src/main/java/it/pagopa/pm/gateway/service/VposService.java
@@ -88,7 +88,7 @@ public class VposService {
         try {
             return processStepZero(request, clientId, mdcFields);
         } catch (Exception e) {
-            log.error(String.format("Error while constructing requestBody for idTransaction %s, cause: %s", idTransaction, e));
+            log.error(String.format("Error while constructing requestBody for idTransaction %s", idTransaction), e);
             return createStepZeroResponse(GENERIC_ERROR_MSG + request.getIdTransaction(), null);
         }
     }

--- a/src/test/java/it/pagopa/pm/gateway/beans/ValidBeans.java
+++ b/src/test/java/it/pagopa/pm/gateway/beans/ValidBeans.java
@@ -54,8 +54,6 @@ import static it.pagopa.pm.gateway.constant.Messages.*;
 import static it.pagopa.pm.gateway.constant.XPayParams.*;
 import static it.pagopa.pm.gateway.dto.enums.CardCircuit.MASTERCARD;
 import static it.pagopa.pm.gateway.dto.enums.PaymentRequestStatusEnum.*;
-import static it.pagopa.pm.gateway.dto.enums.RefundOutcome.KO;
-import static it.pagopa.pm.gateway.dto.enums.RefundOutcome.OK;
 import static it.pagopa.pm.gateway.dto.enums.ThreeDS2ResponseTypeEnum.*;
 import static org.openapitools.client.model.AuthorizationType.IMMEDIATA;
 
@@ -1043,9 +1041,9 @@ public class ValidBeans {
         VposDeleteResponse response = new VposDeleteResponse();
         response.setRequestId(uuid_sample);
         if (isValid) {
-            response.setRefundOutcome(OK.name());
+            response.setStatus("CANCELLED");
         } else {
-            response.setRefundOutcome(KO.name());
+            response.setStatus("CREATED");
         }
         response.setError(error);
         return response;

--- a/src/test/java/it/pagopa/pm/gateway/controller/XPayPaymentControllerTest.java
+++ b/src/test/java/it/pagopa/pm/gateway/controller/XPayPaymentControllerTest.java
@@ -181,6 +181,7 @@ public class XPayPaymentControllerTest {
         PaymentRequestEntity entity = ValidBeans.paymentRequestEntityxPay(xPayAuthRequest, ECOMMERCE_APP_ORIGIN, true, CREATED, false);
         XPayPollingResponse expectedResponse = ValidBeans.createXpayAuthPollingResponse(true, null, false);
         when(paymentRequestRepository.findByGuid(UUID_SAMPLE)).thenReturn(entity);
+        when(clientsConfig.getByKey(any())).thenReturn(clientConfig);
         String url = REQUEST_PAYMENTS_XPAY + "/" + UUID_SAMPLE;
         mvc.perform(get(url)).andExpect(content().json(mapper.writeValueAsString(expectedResponse)));
     }
@@ -205,7 +206,7 @@ public class XPayPaymentControllerTest {
         XPayAuthRequest xPayAuthRequest = ValidBeans.createXPayAuthRequest(true);
         when(paymentRequestRepository.findByGuid(UUID_SAMPLE))
                 .thenReturn(ValidBeans.paymentRequestEntityxPayWithoutHtml(xPayAuthRequest, ECOMMERCE_APP_ORIGIN));
-
+        when(clientsConfig.getByKey(any())).thenReturn(clientConfig);
         String url = REQUEST_PAYMENTS_XPAY + "/" + UUID_SAMPLE;
         mvc.perform(get(url))
                 .andExpect(content().json(mapper.writeValueAsString(ValidBeans.createXpayAuthPollingResponse(false, null, false))));
@@ -594,6 +595,7 @@ public class XPayPaymentControllerTest {
         when(paymentRequestRepository.findByGuid(UUID_SAMPLE))
                 .thenReturn(ValidBeans.paymentRequestEntityxPay(xPayAuthRequest, ECOMMERCE_APP_ORIGIN, true, CANCELLED, false));
         when(clientsConfig.getByKey(any())).thenReturn(clientConfig);
+
         String url = REQUEST_PAYMENTS_XPAY + "/" + UUID_SAMPLE;
         mvc.perform(get(url))
                 .andExpect(content().json(mapper.writeValueAsString(ValidBeans.createXpayAuthPollingResponse(false,
@@ -607,6 +609,7 @@ public class XPayPaymentControllerTest {
                 .thenReturn(ValidBeans.paymentRequestEntityxPay(xPayAuthRequest, ECOMMERCE_APP_ORIGIN, true, CANCELLED,
                         true));
         when(clientsConfig.getByKey(any())).thenReturn(clientConfig);
+
         String url = REQUEST_PAYMENTS_XPAY + "/" + UUID_SAMPLE;
         mvc.perform(get(url))
                 .andExpect(content().json(mapper.writeValueAsString(ValidBeans.createXpayAuthPollingResponse(false,

--- a/src/test/java/it/pagopa/pm/gateway/service/VposDeleteServiceTest.java
+++ b/src/test/java/it/pagopa/pm/gateway/service/VposDeleteServiceTest.java
@@ -36,6 +36,8 @@ public class VposDeleteServiceTest {
 
     public static final String RESULT_CODE_OK = "00";
     public static final String RESULT_CODE_KO = "02";
+    public static final String CREATED = "CREATED";
+    public static final String AUTHORIZED = "AUTHORIZED";
     private final String UUID_SAMPLE = "8d8b30e3-de52-4f1c-a71c-9905a8043dac";
 
     @Mock
@@ -100,6 +102,7 @@ public class VposDeleteServiceTest {
         String requestJson = objectMapper.writeValueAsString(stepZeroRequest);
         entity.setJsonRequest(requestJson);
         entity.setIdTransaction("1235");
+        entity.setStatus(CREATED);
 
         //This param is not validated, so the test doesn't fail
         Map<String, String> params = new HashMap<>();
@@ -115,10 +118,10 @@ public class VposDeleteServiceTest {
         when(vPosResponseUtils.buildOrderStatusResponse(any())).thenReturn(vposOrderStatusResponse);
 
 
-        VposDeleteResponse resposeTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, "Error during orderStatus", false);
+        VposDeleteResponse responseTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, "Error during orderStatus", false);
         VposDeleteResponse responseService = service.startDelete(UUID_SAMPLE);
 
-        assertEquals(resposeTest, responseService);
+        assertEquals(responseTest, responseService);
     }
 
     @Test
@@ -130,6 +133,7 @@ public class VposDeleteServiceTest {
         String requestJson = objectMapper.writeValueAsString(stepZeroRequest);
         entity.setJsonRequest(requestJson);
         entity.setIdTransaction("1235");
+        entity.setStatus(CREATED);
 
         //This param is not validated, so the test doesn't fail
         Map<String, String> params = new HashMap<>();
@@ -149,18 +153,20 @@ public class VposDeleteServiceTest {
         when(vPosResponseUtils.buildAuthResponse(any())).thenReturn(authResponse);
 
 
-        VposDeleteResponse resposeTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, "Error during Revert", false);
+        VposDeleteResponse responseTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, "Error during Revert", false);
         VposDeleteResponse responseService = service.startDelete(UUID_SAMPLE);
 
-        assertEquals(resposeTest, responseService);
+        assertEquals(responseTest, responseService);
     }
 
     @Test
     public void startDelete_Test_EntityNull() {
-        VposDeleteResponse resposeTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, REQUEST_ID_NOT_FOUND_MSG, false);
+        VposDeleteResponse responseTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, REQUEST_ID_NOT_FOUND_MSG, false);
         when(paymentRequestRepository.findByGuid(any())).thenReturn(null);
         VposDeleteResponse responseService = service.startDelete(UUID_SAMPLE);
-        assertEquals(resposeTest, responseService);
+
+        responseTest.setStatus(null);
+        assertEquals(responseTest, responseService);
     }
 
     @Test
@@ -168,10 +174,13 @@ public class VposDeleteServiceTest {
         PaymentRequestEntity entity = new PaymentRequestEntity();
         entity.setIdTransaction("1235");
         entity.setIsRefunded(true);
-        VposDeleteResponse resposeTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, String.format(TRANSACTION_ALREADY_REFUND, entity.getIdTransaction()), false);
+        entity.setStatus(AUTHORIZED);
+        VposDeleteResponse responseTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, String.format(TRANSACTION_ALREADY_REFUND, entity.getIdTransaction()), false);
         when(paymentRequestRepository.findByGuid(any())).thenReturn(entity);
         VposDeleteResponse responseService = service.startDelete(UUID_SAMPLE);
-        assertEquals(resposeTest, responseService);
+
+        responseTest.setStatus(AUTHORIZED);
+        assertEquals(responseTest, responseService);
     }
 
     @Test
@@ -183,6 +192,7 @@ public class VposDeleteServiceTest {
         String requestJson = objectMapper.writeValueAsString(stepZeroRequest);
         entity.setJsonRequest(requestJson);
         entity.setIdTransaction("1235");
+        entity.setStatus(CREATED);
 
         VposDeleteResponse resposeTest = ValidBeans.createVposDeleteResponse(UUID_SAMPLE, GENERIC_REFUND_ERROR_MSG + UUID_SAMPLE, false);
 
@@ -202,6 +212,7 @@ public class VposDeleteServiceTest {
         String requestJson = objectMapper.writeValueAsString(stepZeroRequest);
         entity.setJsonRequest(requestJson);
         entity.setIdTransaction("1235");
+        entity.setStatus(CREATED);
 
         //This param is not validated, so the test doesn't fail
         Map<String, String> params = new HashMap<>();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
XPAY and VPOS responses standardization: the main goal is having the XPAY and VPOS core APIs to behave the same way
This PR adds and removes various fields from the services' responses. In particular:
- Adds **timestamp** to VPOS' POST to start the payment
- Removes **authOutcome** from XPAY's GET
- Adds **authCode** to VPOS' GET for OK cases
- Removes **responseType** from VPOS' GET except for METHOD and CHALLENGE steps
- Adds **redirectUrl** to VPOS' GET for KO cases
- Removes **error** from DELETE's response when it's null
- Removes **refundOutcome** from both VPOS' and XPAY's DELETE
- Adds **status** to XPAY's DELETE
- Adds **redirectUrl** to XPAY's GET when CANCELLED

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have created or updated an API interface.
  - [ ] I have updated the OpenAPI spec
- [ ] I have created or updated a database table
  - [ ] I have updated both the Oracle and Postgres migrations
- [ ] My PR is cohesive and self-contained (rule of thumb: less than 250 changed lines) <!-- If this is not the case please specify why it should not be split into more PRs -->

### Link to story

<!-- Please insert link to the story relative to this task-->